### PR TITLE
修复在Linux 下因设置托盘帮助提示方法不能使用导致无法启动 alist 的故障

### DIFF
--- a/lib/utils/native/tray_helper.dart
+++ b/lib/utils/native/tray_helper.dart
@@ -45,13 +45,19 @@ Future<void> changeTray(bool isRunning) async {
     items.insert(
         2, tm.MenuItem(key: TrayEntry.openGUI.name, label: t.tray.openGUI));
     tm.trayManager.setContextMenu(tm.Menu(items: items));
-    await tm.trayManager.setToolTip(t.tray.workingTooltip);
+    //setToolTip() method is not available on linux,just cancel it！
+    if (!Platform.isLinux) {
+      await tm.trayManager.setToolTip(t.tray.tooltip);
+    }
   } else {
     //add startAlist
     items.insert(1,
         tm.MenuItem(key: TrayEntry.startAlist.name, label: t.tray.startAlist));
     tm.trayManager.setContextMenu(tm.Menu(items: items));
-    await tm.trayManager.setToolTip(t.tray.tooltip);
+    //setToolTip() method is not available on linux,just cancel it！
+    if (!Platform.isLinux) {
+      await tm.trayManager.setToolTip(t.tray.tooltip);
+    }
   }
 }
 


### PR DESCRIPTION
Due to the fact that the **setToolTip** method in the **trap_manager** package cannot be used on Linux , the Alist Helper gets stuck and fails to start the Alist program. There is no response even when clicked. 

The log shows the error "MissingPluginException(No implementation found for method setToolTip on channel tray_manager)". 

By adding conditional judgments and removing the call to the **setToolTip** method if it's on Linux, the failure to start the Alist program on Linux can be fixed.