### PR TITLE
Fixed the issue that the rclone mount path could not be used on Linux.

### DIFF
--- a/lib/provider/rclone_provider.dart
+++ b/lib/provider/rclone_provider.dart
@@ -222,11 +222,13 @@ class RcloneNotifier extends Notifier<RcloneState> {
       }
     }
     if (!vd.isMounted) {
+      //Added support for Linux paths
+      String mountPointOS= Platform.isLinux ? vd.mountPoint:'${vd.mountPoint}:';
       final response = await dio.post(
         '${state.url}/mount/mount',
         data: jsonEncode({
           'fs': '${vd.name}:',
-          'mountPoint': '${vd.mountPoint}:',
+          'mountPoint': mountPointOS,
           'mountType': '',
           'vfsOpt': {
             'CacheMode': cacheMode,
@@ -250,9 +252,11 @@ class RcloneNotifier extends Notifier<RcloneState> {
 
   Future<void> unmountRemote(vd) async {
     if (vd.isMounted) {
+      //Added support for Linux paths
+      String mountPointOS= Platform.isLinux ? vd.mountPoint:'${vd.mountPoint}:';
       final response = await dio.post(
         '${state.url}/mount/unmount',
-        data: jsonEncode({'mountPoint': '${vd.mountPoint}:'}),
+        data: jsonEncode({'mountPoint': mountPointOS}),
         options: option,
       );
 

--- a/lib/widgets/add_new_vdisk.dart
+++ b/lib/widgets/add_new_vdisk.dart
@@ -165,8 +165,15 @@ class AddRcloneDiskForm extends ConsumerWidget {
             validator: (value) {
               if (value == null || value.isEmpty) {
                 return 'Please enter a mount point';
-              } else if (value.length > 1) {
-                return 'Please enter a single character';
+
+              //Linux does not have a Windows drive letter such as "T" or "E", and 
+              //uses an absolute path such as "/path/to/dir" in Linux, so removes 
+              //the one-character limit to accommodate the use of absolute paths in 
+              //Linux systems.
+
+              /* }  
+              else if (value.length > 1) {
+              return 'Please enter a single character'; */
               } else if (!value.contains(RegExp(r'[A-Za-z]'))) {
                 return 'Please enter a letter';
               }


### PR DESCRIPTION
When AlistHelper is running on linux, rclone mounts the local path and shows the error: "No open such directory" or only allows one character to be entered, which is fine under Windows, but Linux doesn't have a drive letter like C: or D:, so it gets an error.

Linux does not have a Windows drive letter such as "T" or "E", and uses an absolute path such as "/path/to/dir" in Linux, so removes the one-character limit to accommodate the use of absolute paths in Linux systems.

And add  Linux path support to fix the issue of mounting path error，such as "failed to mount FUSE fs: cannot open:/xxx/xxx/xxx".

